### PR TITLE
Add `mode` option to support passing vega specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,42 @@ In your Idyll markup,
 
 ```
 
+To use with a `vega` specification, set the mode to `vega` and do not pass the
+data as a separate parameter:
+
+```
+[IdyllVegaLite mode:"vega" spec:`{
+   ...
+   ...
+}` /]
+```
+
 See https://idyll-lang.github.io/examples/csv/ for example usage.
+
+
+## Troubleshooting
+
+Depending on your environment, you may see errors when trying to compile an Idyll document
+that depends on this library. In this case, you can compile using the `compileLibs` option
+to apply all code transformations to the vega dependencies as well, which will make them
+compatible with the rest of the build system:
+
+```
+$ idyll --compileLibs
+```
+
+or specify in `package.json` with:
+
+```
+"idyll": {
+  "compileLibs": true
+}
+```
+
+This option will cause the initial compile time to be slower, but after the first run
+the results are cached and so it should be quicker on subsequent compilation.
+
+## Contributors
+
+- Matthew Conlen (https://github.com/mathisonian)
+- Dan Marshall (https://github.com/danmarshall)

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const React = require('react');
 
-import { VegaLite } from 'react-vega';
+import { VegaLite, Vega } from 'react-vega';
 
 
 
@@ -21,16 +21,70 @@ class IdyllVegaLite extends React.Component {
     })
   }
   render() {
-    const { spec, data, ...props } = this.props;
+    const { spec, data, mode, ...props } = this.props;
+
+    let Runtime = VegaLite;
+    if (this.props.mode === 'vega') {
+      Runtime = Vega;
+    }
+
     const { handler } = this.state;
-    const adjustedSpec = { ...this.props.spec, data: { values: data } };
+    const adjustedSpec = { data: { values: data }, ...this.props.spec };
     return (
-      <VegaLite
+      <Runtime
         {...props}
         spec={adjustedSpec}
         tooltip={handler} />
     );
   }
 }
+
+
+VegaLite._idyll = {
+  name: 'IdyllVegaLite',
+  tagType: 'closed',
+  props: [
+    {
+      name: 'data',
+      type: 'expression',
+      example: `\`[{x: 0, y: 0}, {x: 1, y: 1}]\``
+    },
+    {
+      name: 'spec',
+      type: 'expression',
+      example: `\`{
+  mark: "line",
+  encoding: {
+    x: {
+      field: "x",
+      type: "quantitative"
+    },
+    y: {
+      field: "y",
+      type: "quantitative"
+    }
+  }
+}\``
+    },
+    {
+      name: 'mode',
+      type: 'string',
+      default: `"vega-lite"`,
+      example: `"vega-lite"`
+    },
+    {
+      name: 'width',
+      type: 'value',
+      example: `"container"`
+    },
+    {
+      name: 'height',
+      type: 'number',
+      example: `300`
+    }
+  ]
+};
+
+
 
 module.exports = IdyllVegaLite;

--- a/index.js
+++ b/index.js
@@ -22,14 +22,19 @@ class IdyllVegaLite extends React.Component {
   }
   render() {
     const { spec, data, mode, ...props } = this.props;
+    let adjustedSpec = spec;
 
     let Runtime = VegaLite;
     if (this.props.mode === 'vega') {
       Runtime = Vega;
+    } else {
+      //vega-lite spec. Modify the spec if data was passed.
+      if (data) {
+        adjustedSpec = { data: { values: data }, ...spec };
+      }
     }
 
     const { handler } = this.state;
-    const adjustedSpec = { data: { values: data }, ...this.props.spec };
     return (
       <Runtime
         {...props}

--- a/index.js
+++ b/index.js
@@ -14,6 +14,10 @@ class IdyllVegaLite extends React.Component {
     }
   }
 
+  isVegaSpec() {
+    return this.props.mode === 'vega' || (this.props.spec.$schema && this.props.spec.$schema.startsWith("https://vega.github.io/schema/vega/"))
+  }
+
   componentDidMount() {
     const { Handler } = require('vega-tooltip')
     this.setState({
@@ -25,8 +29,11 @@ class IdyllVegaLite extends React.Component {
     let adjustedSpec = spec;
 
     let Runtime = VegaLite;
-    if (this.props.mode === 'vega') {
+    if (this.isVegaSpec()) {
       Runtime = Vega;
+      if (!adjustedSpec.data) {
+        console.warn('If passing a vega spec you must provide a data object in the spec.');
+      }
     } else {
       //vega-lite spec. Modify the spec if data was passed.
       if (data) {


### PR DESCRIPTION
So you can do this:

```
[IdyllVegaLite mode:"vega" spec:`{ ... }`  /]
```


Note - I'm not sure this will work with `width: "container"` you may have to pass an explicit width. I also added a note about how to set up aliases in the readme, so you can write something like 

```
[Plot mode:"vega" spec:`{ ... }`  /]
```

for readability. 